### PR TITLE
use set mass in Tutorial-DarkPhoton.ipynb

### DIFF
--- a/Tutorial-DarkPhoton.ipynb
+++ b/Tutorial-DarkPhoton.ipynb
@@ -577,7 +577,7 @@
    ],
    "source": [
     "mass = 0.1 \n",
-    "output = foresee.get_events(mass=0.1, energy=energy, couplings=np.logspace(-8,-3,6), )\n",
+    "output = foresee.get_events(mass=mass, energy=energy, couplings=np.logspace(-8,-3,6), )\n",
     "coups, ctaus, nsigs, energies, weights, _ = output\n",
     "for coup,ctau,nsig in zip(coups, ctaus, nsigs):\n",
     "    print (\"epsilon =\", '{:5.3e}'.format(coup), \": nsignal =\", '{:5.3e}'.format(nsig))"


### PR DESCRIPTION
Function get_event was not using set mass from 1 line above.